### PR TITLE
resin-image-flasher-unwrap: Do not check image format if not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # resin-image-flasher-unwrap
 
+BalenaOS distinguishes between devices that can boot directly a raw image programmed into a SD card or USB disk, and those that boot a flasher image from SD card or USB which then programs the image it encloses into some internal storage like a eMMC.
+
+The second is referred to as a resin-image flasher and contains a resin-image.
+
 This small tool provides the ability to get the embedded resin image in a resin image flasher and configures it accordingly.
 
 ## How to use
@@ -11,6 +15,28 @@ This tool can be easily ran by either using the prebuilt docker image or running
 Run `docker-run` or adapt it based on your needs. It takes one argument (the
 absolute path of the flasher image) and outputs, in the `output` directory, the
 resin image.
+
+#### Usage examples
+
+Balena device types can either boot a resin-image directly, or boot a flasher
+image that on boot flashes the resin-image it contains.
+
+To unwrap the resin image from a resin image flasher image:
+
+ ./docker-run /path/to/balena.img
+
+This action results in an image in the output directory that can be directly
+flashed using Etcher.
+
+To convert it into a different format to use in emulators, specify the image
+format as extra arguments:
+
+ ./docker-run /path/to/balena.img -F vmdk
+
+ You can optionally set the image size to a new value in bytes (see qemu-img man page for details):
+
+
+ ./docker-run /path/to/balena.img -F vmdk -s <bytes>
 
 ### Run the script directly
 

--- a/resin-image-flasher-unwrap
+++ b/resin-image-flasher-unwrap
@@ -104,14 +104,16 @@ if [ ! -z "$IMAGE_SIZE" ] && [ -z "$IMAGE_FORMAT" ]; then
 fi
 
 # Ensure the format is valid...
-case $IMAGE_FORMAT in
-	vdi|vhd|vmdk)
-		;;
-	*)
-		log ERROR "--format can only be one of vdi/vhd/vmdk"
-		exit 1
-		;;
-esac
+if [ -n "${IMAGE_FORMAT}" ]; then
+	case $IMAGE_FORMAT in
+		vdi|vhd|vmdk)
+			;;
+		*)
+			log ERROR "--format can only be one of vdi/vhd/vmdk"
+			exit 1
+			;;
+	esac
+fi
 
 cleanup () {
 	EXIT_CODE=$?


### PR DESCRIPTION
The standard flow for this tool is to unwrap a resin-image from a
resin-image-flasher.

On commit cea5fc2a5623 the option of converting it to a different format to
use in emulators was introduced, but the image format was made compulsory
with the script exiting if not provided.

This commit only checks the validity of image format when actually provided.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>