### PR TITLE
Fixes undefined 'USER_ID' usage

### DIFF
--- a/balena-image-flasher-unwrap
+++ b/balena-image-flasher-unwrap
@@ -84,7 +84,7 @@ while [[ $# -gt 0 ]]; do
 			IMAGE_SIZE=$2
 			shift
 			;;
-		-F|--format)			
+		-F|--format)
 			IMAGE_FORMAT=$2
 			shift
 			;;
@@ -146,7 +146,7 @@ cleanup () {
 				"$qemu_img" convert -f qcow2 "$new_balena_image" -O vmdk "$converted_image" -o compat6
 				;;
 		esac
-				
+
 		rm -f "$balena_image" "$new_balena_image"
 		balena_image="$converted_image"
 	fi

--- a/docker-run
+++ b/docker-run
@@ -39,6 +39,6 @@ docker run --privileged --rm \
 	-v /dev:/dev \
 	-v "$SCRIPTPATH/output":/output \
 	-v "$BALENA_IMAGE_FLASHER":"/$balena_image_name" \
-	-e USER_ID \
+	-e "$USER_ID" \
 	"$extraction_container" \
 	balena-image-flasher-unwrap --balena-image-flasher "/$balena_image_name" -o /output $flasher_args


### PR DESCRIPTION
The variable `$USER_ID` was defined but then in the actual Docker run, only `USER_ID` was passed on, which broke the script.

(Also includes a minor white space cleanup)