### PR TITLE
balena-image-flasher-unwrap: extend file match to include extension

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1,0 +1,30 @@
+name: Flowzone
+
+on:
+  pull_request:
+    types: [opened, synchronize, closed]
+    branches:
+      - "main"
+      - "master"
+      - '20[0-9][0-9].[0-1]?[1470].x'
+  pull_request_target:
+    types: [opened, synchronize, closed]
+    branches:
+      - "main"
+      - "master"
+      - '20[0-9][0-9].[0-1]?[1470].x'
+
+jobs:
+  flowzone:
+    name: Flowzone
+    uses: product-os/flowzone/.github/workflows/flowzone.yml@master
+    # prevent duplicate workflow executions for pull_request and pull_request_target
+    if: |
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event_name == 'pull_request'
+      ) || (
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        github.event_name == 'pull_request_target'
+      )
+    secrets: inherit

--- a/balena-image-flasher-unwrap
+++ b/balena-image-flasher-unwrap
@@ -190,7 +190,7 @@ mount "${balena_image_flasher_loop_dev}p2" "$balena_image_flasher_root_mnt" > /d
 flasher_image_basename="$(basename "$balena_image_flasher")"
 image_basename="$OUTPUT_DIR/$(echo ${flasher_image_basename%.*} | sed 's/-flasher//g')"
 
-balena_image="$(find "$balena_image_flasher_root_mnt/opt" -type f | head -n1)"
+balena_image="$(find "$balena_image_flasher_root_mnt/opt" -type f -name *.balenaos-img | head -n1)"
 [ -z "$balena_image" ] && log ERROR "The balena image flasher doesn't contain a balena image."
 cp "$balena_image" "$image_basename.img"
 balena_image="$image_basename.img"


### PR DESCRIPTION
New images include both a raw image and its signature, which makes the script fail when the match returns the signature file.

This commit introduces an exact match on the `balenaos-img` extension to prevent this.

Change-type: patch